### PR TITLE
Add a --dry-run option

### DIFF
--- a/cherry_picker.py
+++ b/cherry_picker.py
@@ -5,16 +5,22 @@ import webbrowser
 
 
 @click.command()
+@click.option('--dryrun', is_flag=True)
 @click.argument('commit_sha1', 'The commit sha1 to be cherry-picked')
 @click.argument('branches', 'The branches to backport to', nargs=-1)
-def cherry_pick(commit_sha1, branches):
+def cherry_pick(dryrun, commit_sha1, branches):
     if not os.path.exists('./pyconfig.h.in'):
         os.chdir('./cpython/')
-    upstream = get_git_upstream_remote()
-    username = get_forked_repo_name()
+    upstream = get_git_fetch_remote()
+    pr_remote = get_git_push_remote()
+    username = get_forked_repo_name(pr_remote)
+
+    if dryrun:
+       click.echo("Dry run requested, listing expected command sequence")
+
 
     click.echo("fetching upstream ...")
-    run_cmd(f"git fetch {upstream}")
+    run_cmd(f"git fetch {upstream}", dryrun=dryrun)
 
     if not branches:
         raise ValueError("at least one branch is required")
@@ -23,53 +29,71 @@ def cherry_pick(commit_sha1, branches):
         click.echo(f"Now backporting '{commit_sha1}' into '{branch}'")
 
         # git checkout -b 61e2bc7-3.5 upstream/3.5
-        cherry_pick_branch = f"{commit_sha1[:7]}-{branch}"
+        cherry_pick_branch = f"backport-{commit_sha1[:7]}-{branch}"
         cmd = f"git checkout -b {cherry_pick_branch} {upstream}/{branch}"
-        run_cmd(cmd)
+        run_cmd(cmd, dryrun=dryrun)
 
         cmd = f"git cherry-pick -x {commit_sha1}"
-        if run_cmd(cmd):
-            cmd = f"git push origin {cherry_pick_branch}"
-            if not run_cmd(cmd):
-                click.echo(f"Failed to push to origin :(")
+        if run_cmd(cmd, dryrun=dryrun):
+            cmd = f"git push {pr_remote} {cherry_pick_branch}"
+            if not run_cmd(cmd, dryrun=dryrun):
+                click.echo(f"Failed to push to {pr_remote} :(")
             else:
-                open_pr(username, branch, cherry_pick_branch)
+                open_pr(username, branch, cherry_pick_branch, dryrun=dryrun)
         else:
             click.echo(f"Failed to cherry-pick {commit_sha1} into {branch} :(")
 
         cmd = "git checkout master"
-        run_cmd(cmd)
+        run_cmd(cmd, dryrun=dryrun)
 
         cmd = f"git branch -D {cherry_pick_branch}"
-        if run_cmd(cmd):
-            click.echo(f"branch {cherry_pick_branch} has been deleted.")
+        if run_cmd(cmd, dryrun=dryrun):
+            if not dryrun:
+                click.echo(f"branch {cherry_pick_branch} has been deleted.")
         else:
             click.echo(f"branch {cherry_pick_branch} NOT deleted.")
 
 
-def get_git_upstream_remote():
+def get_git_fetch_remote():
     """Get the remote name to use for upstream branches
     Uses "upstream" if it exists, "origin" otherwise
     """
     cmd = "git remote get-url upstream"
-    if run_cmd(cmd):
+    if run_cmd(cmd, dryrun=False):
         return "upstream"
     else:
         return "origin"
 
+def get_git_push_remote():
+    """Get the remote name to use for upstream branches
+    Uses "pr" if it exists, "origin" otherwise
+    """
+    cmd = "git remote get-url pr"
+    if run_cmd(cmd, dryrun=False):
+        return "pr"
+    else:
+        return "origin"
 
-def get_forked_repo_name():
+
+def get_forked_repo_name(pr_remote):
     """
     Return 'myusername' out of https://github.com/myusername/cpython
     :return:
     """
-    cmd = "git config --get remote.origin.url"
+    cmd = f"git config --get remote.{pr_remote}.url"
     result = subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT).decode('utf-8')
-    username = result[len("https://github.com/"):result.index('/cpython.git')]
+    username_end = result.index('/cpython.git')
+    if result.startswith("https"):
+        username = result[len("https://github.com/"):username_end]
+    else:
+        username = result[len("git@github.com:"):username_end]
     return username
 
 
-def run_cmd(cmd):
+def run_cmd(cmd, *, dryrun=False):
+    if dryrun:
+        click.echo(f"dryrun: {cmd}")
+        return True
     try:
         subprocess.check_output(cmd.split())
     except subprocess.CalledProcessError:
@@ -77,11 +101,14 @@ def run_cmd(cmd):
     return True
 
 
-def open_pr(forked_repo, base_branch, cherry_pick_branch):
+def open_pr(forked_repo, base_branch, cherry_pick_branch, *, dryrun=False):
     """
     construct the url for pull request and open it in the web browser
     """
     url = f"https://github.com/python/cpython/compare/{base_branch}...{forked_repo}:{cherry_pick_branch}?expand=1"
+    if dryrun:
+        click.echo(f"dryrun: Create new PR: {url}")
+        return
     webbrowser.open_new_tab(url)
 
 

--- a/readme.rst
+++ b/readme.rst
@@ -34,6 +34,13 @@ Requires Python 3.6 and virtualenv.
     (venv) $ git remote add upstream https://github.com/python/cpython.git
     (venv) $ cd ../
 
+The following `git remote` configurations are supported:
+
+* if an `upstream` remote is defined, then it is used as the source of
+  upstream changes and as the base for cherry-pick branches. Otherwise,
+  `origin` is used for that purpose.
+* if a `pr` remote is defined, then it is used as the target for pushing
+  cherry-pick branches. Otherwise, `origin` is used for that purpose.
 
 Cherry-picking :snake: :cherries: :pick:
 ==============
@@ -62,19 +69,26 @@ What this will do:
     
     (venv) $ git fetch upstream
     
-    (venv) $ git checkout -b 6de2b78-3.5 upstream/3.5
+    (venv) $ git checkout -b backport-6de2b78-3.5 upstream/3.5
     (venv) $ git cherry-pick -x 6de2b7817f-some-commit-sha1-d064 
-    (venv) $ git push origin 6de2b78-3.5
+    (venv) $ git push origin backport-6de2b78-3.5
     (venv) $ git checkout master
-    (venv) $ git branch -D 6de2b78-3.5
+    (venv) $ git branch -D backport-6de2b78-3.5
     
-    (venv) $ git checkout -b 6de2b78-3.6 upstream/3.6
+    (venv) $ git checkout -b backport-6de2b78-3.6 upstream/3.6
     (venv) $ git cherry-pick -x 6de2b7817f-some-commit-sha1-d064 
-    (venv) $ git push origin 6de2b78-3.6
+    (venv) $ git push origin backport-6de2b78-3.6
     (venv) $ git checkout master
-    (venv) $ git branch -D 6de2b78-3.6
+    (venv) $ git branch -D backport-6de2b78-3.6
+
+After each push command, it will also open a browser tab ready to submit
+the relevant PR back to the main CPython repository.
 
 In case of merge conflicts or errors, then... the script will fail :stuck_out_tongue:
+
+Passing the `--dryrun` option will cause the script to print out all the
+steps it would execute without actually executing any of them (although the
+latest upstream changes will be fetched even in dryrun mode)
 
 
 Creating Pull Requests


### PR DESCRIPTION
- still fetches upstream changes
- otherwise just prints commands that would be executed if
  everything runs without errors
- also prints the PR creation URLs that would be opened
- does NOT do any local checkouts, cherry-picks, branch
  creation or branch deletion
- does NOT actually create any PRs

Side effect: handles the cases where the remote to push to is
called 'pr' and/or is checked out over SSH rather than HTTPS.

Side effect: adds a "backport-" prefix to the cherry-pick branches